### PR TITLE
Integrate desktop-build support to main branch

### DIFF
--- a/acc-control/Makefile
+++ b/acc-control/Makefile
@@ -1,4 +1,4 @@
-CFLAGS := -Wall -Wextra -pthread -g -I./include
+override CFLAGS += -Wall -Wextra -pthread -g -I./include
 LDFLAGS += -lrt -pthread -lpigpiod_if2 -llirc_client
 
 SRC_DIR := source

--- a/acc-control/include/gpio.h
+++ b/acc-control/include/gpio.h
@@ -5,7 +5,9 @@
 #ifndef _GPIO_H_
 #define _GPIO_H_
 
+#ifndef _DESKTOP_BUILD_
 #include <pigpiod_if2.h>
+#endif
 
 #define _GPIO_H_LED_RED         23
 #define _GPIO_H_LED_BLUE        22

--- a/acc-control/makedesk.sh
+++ b/acc-control/makedesk.sh
@@ -1,0 +1,3 @@
+#/bin/bash
+
+make --debug CFLAGS+=-D_DESKTOP_BUILD_=1 LDFLAGS=-pthread

--- a/acc-control/source/main.c
+++ b/acc-control/source/main.c
@@ -13,7 +13,7 @@ int main() {
     struct infra_st infra;
 
     r = GPIO_initialize(&gpio);
-    assert(r == 0);
+    assert(r >= 0);
     r = infrared_initialize(&infra);
     assert(r == 0);
 


### PR DESCRIPTION
This pull request would add support for building on a desktop computer without the LIRC and pigpio libraries. The calls to those libraries are replaced with printed messages. A script `makedesk.sh` contains the right `make` command. Works on macOS and Linux, and probably other Unix-like environments.